### PR TITLE
Install package globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Track WordPress plugins and themes statistics from the command line.
 ## Install
 
 ```
-$ npm install wp-stats
+$ npm install -g wp-stats
 ```
 
 ## Commands


### PR DESCRIPTION
CLIs like this would be used globally instead of installing in a project. This updates readme to use `npm install -g wp-stats` instead of `npm install wp-stats`